### PR TITLE
Add is_attached metacheck

### DIFF
--- a/lib/metachecks/checks/AwsAutoScalingLaunchConfiguration.py
+++ b/lib/metachecks/checks/AwsAutoScalingLaunchConfiguration.py
@@ -166,6 +166,11 @@ class Metacheck(MetaChecksBase):
                         return False
         return True
 
+    def is_attached(self):
+        if self.its_associated_with_autoscaling_group():
+            return True
+        return False
+
     def checks(self):
         checks = [
             "is_instance_metadata_v2",
@@ -176,5 +181,6 @@ class Metacheck(MetaChecksBase):
             "it_associates_public_ip",
             "is_public",
             "is_encrypted",
+            "is_attached",
         ]
         return checks

--- a/lib/metachecks/checks/AwsEc2LaunchTemplate.py
+++ b/lib/metachecks/checks/AwsEc2LaunchTemplate.py
@@ -197,6 +197,12 @@ class Metacheck(MetaChecksBase):
             return self.iam_roles
         return False
 
+    def is_attached(self):
+        if self.its_associated_with_autoscaling_group():
+            return True
+        return False
+    
+
     def checks(self):
         checks = [
             "is_instance_metadata_v2",
@@ -208,5 +214,6 @@ class Metacheck(MetaChecksBase):
             "is_encrypted",
             "it_associates_public_ip",
             "its_associated_with_iam_roles",
+            "is_attached",
         ]
         return checks

--- a/lib/metachecks/checks/AwsEc2NetworkAcl.py
+++ b/lib/metachecks/checks/AwsEc2NetworkAcl.py
@@ -121,6 +121,12 @@ class Metacheck(MetaChecksBase):
                 return True
         return False
 
+    def is_attached(self):
+        if self.network_acl:
+            if self.its_associated_with_subnets():
+                return True
+        return False
+
     def checks(self):
         checks = [
             "its_associated_with_subnets",
@@ -128,5 +134,6 @@ class Metacheck(MetaChecksBase):
             "is_ingress_rules_unrestricted",
             "is_egress_rules_unrestricted",
             "is_public",
+            "is_attached",
         ]
         return checks

--- a/lib/metachecks/checks/AwsEc2SecurityGroup.py
+++ b/lib/metachecks/checks/AwsEc2SecurityGroup.py
@@ -240,6 +240,12 @@ class Metacheck(MetaChecksBase):
                         return True
         return False
 
+    def is_attached(self):
+        if self.all_security_group:
+            if self.its_associated_with_network_interfaces() or self.its_associated_with_ec2_instances() or self.its_associated_with_ips_public() or self.its_associated_with_managed_services():
+                return True
+        return False
+
     def checks(self):
         checks = [
             "its_associated_with_network_interfaces",
@@ -251,5 +257,6 @@ class Metacheck(MetaChecksBase):
             "is_egress_rules_unrestricted",
             "is_public",
             "is_default",
+            "is_attached",
         ]
         return checks


### PR DESCRIPTION
Adding `is_attached` MetaCheck for resources:
- `AwsAutoScalingLaunchConfiguration`
- `AwsEc2LaunchTemplate`
- `AwsEc2NetworkAcl`
- `AwsEc2SecurityGroup`