### PR TITLE
S3 improvements

### DIFF
--- a/lib/config/configuration.py
+++ b/lib/config/configuration.py
@@ -1,3 +1,9 @@
-trusted_accounts = [""]
+# Security Hub Configurations
 
 sh_default_filters = {"RecordState": ["ACTIVE"], "WorkflowStatus": ["NEW"]}
+
+
+# MetaCheck configurations
+
+# List of AWS accounts that are trusted and not considered as external. This is used in the is_principal_external MetaCheck for policies.
+trusted_accounts = []

--- a/lib/metachecks/checks/AwsS3Bucket.py
+++ b/lib/metachecks/checks/AwsS3Bucket.py
@@ -77,34 +77,31 @@ class Metacheck(MetaChecksBase):
     def get_bucket_public_access_block(self):
         try:
             response = self.client.get_public_access_block(Bucket=self.resource_id)
+            if response["PublicAccessBlockConfiguration"]:
+                for key, value in response["PublicAccessBlockConfiguration"].items():
+                    if value == False:
+                        return False
+                return True
         except ClientError as err:
-            if err.response["Error"]["Code"] == "NoSuchPublicAccessBlockConfiguration":
-                return False
-            else:
+            if not err.response["Error"]["Code"] == "NoSuchPublicAccessBlockConfiguration":
                 self.logger.error(
                     "Failed to get_public_access_block {}, {}".format(
                         self.resource_id, err
                     )
                 )
-                return False
-        return response["PublicAccessBlockConfiguration"]
+            return False
 
     def get_bucket_encryption(self):
         try:
             response = self.client.get_bucket_encryption(Bucket=self.resource_id)
         except ClientError as err:
-            if (
-                err.response["Error"]["Code"]
-                == "ServerSideEncryptionConfigurationNotFoundError"
-            ):
-                return False
-            else:
+            if not err.response["Error"]["Code"] == "ServerSideEncryptionConfigurationNotFoundError":
                 self.logger.error(
                     "Failed to get_bucket_encryption {}, {}".format(
                         self.resource_id, err
                     )
                 )
-                return False
+            return False
         return response["ServerSideEncryptionConfiguration"]["Rules"]
 
     # Resource Policy
@@ -113,20 +110,17 @@ class Metacheck(MetaChecksBase):
         try:
             response = self.client.get_bucket_policy(Bucket=self.resource_id)
         except ClientError as err:
-            if err.response["Error"]["Code"] == "NoSuchBucketPolicy":
-                return False
-            else:
+            if not err.response["Error"]["Code"] == "NoSuchBucketPolicy":
                 self.logger.error(
                     "Failed to get_bucket_policy {}, {}".format(self.resource_id, err)
                 )
-                return False
+            return False
 
         if response["Policy"]:
             policy_json = json.loads(response["Policy"])
             checked_policy = PolicyHelper(
                 self.logger, self.finding, policy_json
             ).check_policy()
-            # policy = {"policy_checks": checked_policy, "policy": policy_json}
             return checked_policy
 
         return False

--- a/lib/metachecks/checks/AwsS3Bucket.py
+++ b/lib/metachecks/checks/AwsS3Bucket.py
@@ -77,11 +77,7 @@ class Metacheck(MetaChecksBase):
     def get_bucket_public_access_block(self):
         try:
             response = self.client.get_public_access_block(Bucket=self.resource_id)
-            if response["PublicAccessBlockConfiguration"]:
-                for key, value in response["PublicAccessBlockConfiguration"].items():
-                    if value == False:
-                        return False
-                return True
+            return response.get("PublicAccessBlockConfiguration")
         except ClientError as err:
             if not err.response["Error"]["Code"] == "NoSuchPublicAccessBlockConfiguration":
                 self.logger.error(
@@ -168,7 +164,10 @@ class Metacheck(MetaChecksBase):
 
     def it_has_public_access_block_enabled(self):
         if self.bucket_public_access_block:
-            return self.bucket_public_access_block
+            for key, value in self.bucket_public_access_block.items():
+                if value == False:
+                    return False
+            return True
         return False
 
     def it_has_website_enabled(self):


### PR DESCRIPTION
- `it_has_public_access_block_enabled` MetaCheck was returning the content of the public block always, meaning it was always True for filters. 
- `is_principal_external` was being executed even if `trusted_accounts` was empty, meaning always True because the account was never in an empty list. 
- Other small improvements