### PR TITLE
feat(lambda): Security Hub Custom Actions and Lambda Improvements

### DIFF
--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -103,20 +103,6 @@ def get_parser():
         required=False,
     )
     group_security_hub.add_argument(
-        "--update-findings",
-        default=None,
-        help='Use this option to update the result findings Workflow Status (with a Note). Use --update-findings Workflow=NOTIFIED|RESOLVED|SUPPRESSED|NEW Note="You can whatever you like here, like a ticket ID, you will see this Note on your SH "Updated at" colum',
-        required=False,
-        nargs="*",
-        action=KeyValue,
-    )
-    group_security_hub.add_argument(
-        "--enrich-findings",
-        help="Use this option to update the results findings UserDefinedFields with the output of Meta Checks and/or Meta Tags. Use with --meta-checks and/or --meta-tags",
-        required=False,
-        action=argparse.BooleanOptionalAction,
-    )
-    group_security_hub.add_argument(
         "--inputs",
         choices=["securityhub", "file-asff"],
         default=["securityhub"],
@@ -130,6 +116,30 @@ def get_parser():
         nargs="+",
         help="Specify ASFF file path for use with --input-asff file-asff-1, file-asff-2",
         required=False,
+    )
+
+    # Group: Security Hub Actions
+    group_actions = parser.add_argument_group("Security Hub Options")
+    group_actions.add_argument(
+        "--update-findings",
+        default=None,
+        help='Use this option to update the result findings Workflow Status (with a Note). Use --update-findings Workflow=NOTIFIED|RESOLVED|SUPPRESSED|NEW Note="You can whatever you like here, like a ticket ID, you will see this Note on your SH "Updated at" colum',
+        required=False,
+        nargs="*",
+        action=KeyValue,
+    )
+    group_actions.add_argument(
+        "--enrich-findings",
+        help="Use this option to update the results findings UserDefinedFields with the output of Meta Checks and/or Meta Tags. Use with --meta-checks and/or --meta-tags",
+        required=False,
+        action=argparse.BooleanOptionalAction,
+    )
+    group_actions.add_argument(
+        "--actions-confirmation",
+        default=True,
+        help="Use this option to execute the security hub actions without confirmation",
+        required=False,
+        action=argparse.BooleanOptionalAction,
     )
 
     # Group: Meta Options
@@ -213,6 +223,7 @@ def get_parser():
             "json-inventory",
             "html",
             "csv",
+            "lambda"
         ],
         default=[
             "json-short",
@@ -360,16 +371,19 @@ def print_title_line(text, ch="-", length=78, banners=True):
     print("\n" + banner)
 
 
-def confirm_choice(message):
+def confirm_choice(message, actions_confirmation=True):
     """Simple function to confirm the action, returns True or False based on user entry"""
-    confirm = input(message + " [c]Confirm or [v]Void: ")
-    if confirm != "c" and confirm != "v":
-        print("\n Invalid Option. Please Enter a Valid Option.")
-        return confirm_choice(message)
-    if confirm == "c":
+    if actions_confirmation:
+        confirm = input(message + " [c]Confirm or [v]Void: ")
+        if confirm != "c" and confirm != "v":
+            print("\n Invalid Option. Please Enter a Valid Option.")
+            return confirm_choice(message)
+        if confirm == "c":
+            return True
+        return False
+    else:
+        print("Actions confirmation disabled: continuing with the action...")
         return True
-    return False
-
 
 def test_python_version():
     """Check Python Version"""

--- a/lib/lambda.py
+++ b/lib/lambda.py
@@ -1,18 +1,37 @@
 import lib.main
-
+from lib.helpers import (
+    get_logger,
+)
 
 def lambda_handler(event, context):
 
-    # This could be improved:
-    # - Reading from the event that could be a finding
-    # - Dynamic options from environment or event
+    logger = get_logger("INFO")
 
     LAMBDA_OPTIONS = ["--output-modes", "lambda", "--no-banners"]
+    # Add your custom options here (e.g. ["--sh-filters", "Id=arn::::010101010101", "--meta-checks"])
     CUSTOM_OPTIONS = []
+    # Add your custom actions here (e.g. ["--enrich-findings", "--no-actions-confirmation"])
+    CUSTOM_ACTIONS = ["--no-actions-confirmation"]
 
-    # CUSTOM_OPTIONS = ["--sh-filters", "Id=arn::::010101010101"]
+    event_source = event.get("source")
+    event_detail_type = event.get("detail-type")
+    logger.info("Event Source: %s (%s)", event_source, event_detail_type)
 
-    OPTIONS = LAMBDA_OPTIONS + CUSTOM_OPTIONS
+    # Code to handle Security Hub Custom Actions, execution by finding
+    if event_source == "aws.securityhub" and event_detail_type == "Security Hub Findings - Custom Action":
+        event_detail = event.get("detail")
+        action_name = event_detail.get("actionName")
+        logger.info("Security Hub Custom Action: %s", action_name)
+        for finding in event_detail.get("findings"):
+            finding_id = finding.get("Id")
+            logger.info("Security Hub Finding: %s", finding_id)
+            LAMBDA_OPTIONS = ["--output-modes", "lambda", "--no-banners", "--sh-filters", f"Id={finding_id}"]
+            CUSTOM_OPTIONS = ["--meta-checks", "--meta-tags", "--meta-trails", "--meta-account"]
+            CUSTOM_ACTIONS = ["--enrich-findings", "--no-actions-confirmation"]
 
+    OPTIONS = LAMBDA_OPTIONS + CUSTOM_OPTIONS + CUSTOM_ACTIONS
+
+    logger.info("Executing with options: %s", OPTIONS)
     exec = lib.main.main(OPTIONS)
+    print(exec)
     return exec

--- a/lib/main.py
+++ b/lib/main.py
@@ -225,9 +225,10 @@ def update_findings(
     sh_region,
     update_filters,
     sh_profile,
+    actions_confirmation
 ):
     sh = SecurityHub(logger, sh_region, sh_account, sh_role, sh_profile)
-    if confirm_choice("Are you sure you want to update all findings?"):
+    if confirm_choice("Are you sure you want to update all findings?", actions_confirmation):
         update_multiple = sh.update_findings_workflow(mh_findings, update_filters)
         update_multiple_ProcessedFinding = []
         update_multiple_UnprocessedFindings = []
@@ -247,9 +248,9 @@ def update_findings(
     return [], []
 
 
-def enrich_findings(logger, mh_findings, sh_account, sh_role, sh_region, sh_profile):
+def enrich_findings(logger, mh_findings, sh_account, sh_role, sh_region, sh_profile, actions_confirmation):
     sh = SecurityHub(logger, sh_region, sh_account, sh_role, sh_profile)
-    if confirm_choice("Are you sure you want to enrich all findings?"):
+    if confirm_choice("Are you sure you want to enrich all findings?", actions_confirmation):
         update_multiple = sh.update_findings_meta(mh_findings)
         update_multiple_ProcessedFinding = []
         update_multiple_UnprocessedFindings = []
@@ -551,6 +552,7 @@ def main(args):
     print_table("MetaAccount: ", str(args.meta_account), banners=banners)
     print_table("Update Findings: ", str(args.update_findings), banners=banners)
     print_table("Enrich Findings: ", str(args.enrich_findings), banners=banners)
+    print_table("Actions Confirmation: ", str(args.actions_confirmation), banners=banners)
     print_table("List Findings: ", str(args.list_findings), banners=banners)
     print_table("Output Modes: ", str(args.output_modes), banners=banners)
     print_table("Input: ", str(args.inputs), banners=banners)
@@ -578,12 +580,6 @@ def main(args):
         metaaccount=args.meta_account,
         sh_profile=args.sh_profile,
     )
-
-    if "lambda" in args.output_modes:
-        # This needs to be improved
-        if mh_findings:
-            return mh_findings_short
-        return False
 
     if mh_findings:
         for out in args.list_findings:
@@ -652,6 +648,9 @@ def main(args):
             "Findings to update: ", str(count_mh_findings(mh_findings)), banners=banners
         )
         print_table("Update: ", str(args.update_findings), banners=banners)
+        if "lambda" in args.output_modes:
+            print(
+                "Updating findings: ", str(count_mh_findings(mh_findings)), "with:", str(args.update_findings))
         if mh_findings:
             UPProcessedFindings, UPUnprocessedFindings = update_findings(
                 logger,
@@ -662,6 +661,7 @@ def main(args):
                 sh_region,
                 update_findings_filters,
                 args.sh_profile,
+                args.actions_confirmation,
             )
         print_title_line("Results", banners=banners)
         print_table(
@@ -678,6 +678,9 @@ def main(args):
         print_table(
             "Findings to enrich: ", str(count_mh_findings(mh_findings)), banners=banners
         )
+        if "lambda" in args.output_modes:
+            print(
+                "Enriching findings: ", str(count_mh_findings(mh_findings)))
         if mh_findings:
             ENProcessedFindings, ENUnprocessedFindings = enrich_findings(
                 logger,
@@ -686,6 +689,7 @@ def main(args):
                 args.sh_assume_role,
                 sh_region,
                 args.sh_profile,
+                args.actions_confirmation,
             )
         print_title_line("Results", banners=banners)
         print_table(
@@ -695,6 +699,8 @@ def main(args):
             "UnprocessedFindings: ", str(len(ENUnprocessedFindings)), banners=banners
         )
 
+    if "lambda" in args.output_modes:
+        return mh_findings_short
 
 if __name__ == "__main__":
     main(argv[1:])

--- a/lib/securityhub.py
+++ b/lib/securityhub.py
@@ -116,6 +116,17 @@ class SecurityHub:
 
     def update_findings_meta(self, mh_findings):
         response_multiple = []
+        # Convert metachecks to booleans
+        for resource_arn in mh_findings:
+            if (
+                "metachecks" in mh_findings[resource_arn]
+                and mh_findings[resource_arn]["metachecks"]
+            ):
+                for metacheck in mh_findings[resource_arn]["metachecks"]:
+                    if bool(mh_findings[resource_arn]["metachecks"][metacheck]):
+                        mh_findings[resource_arn]["metachecks"][metacheck] = True
+                    else:
+                        mh_findings[resource_arn]["metachecks"][metacheck] = False
         for mh_finding in mh_findings:
             # MetaTags
             try:
@@ -135,8 +146,26 @@ class SecurityHub:
                 finding_metachecks = {}
             for key in list(finding_metachecks):
                 finding_metachecks[key] = str(finding_metachecks[key])
+            # MetaAccount
+            try:
+                finding_metaaccount = mh_findings[mh_finding]["metaaccount"]
+                if not finding_metaaccount:
+                    finding_metaaccount = {}
+            except KeyError:
+                finding_metaaccount = {}
+            for key in list(finding_metaaccount):
+                finding_metaaccount[key] = str(finding_metaaccount[key])
+            # MetaTrails
+            try:
+                finding_metatrails = mh_findings[mh_finding]["metatrails"]
+                if not finding_metatrails:
+                    finding_metatrails = {}
+            except KeyError:
+                finding_metatrails = {}
+            for key in list(finding_metatrails):
+                finding_metatrails[key] = str(finding_metatrails[key])
             # Combining MetaChecks and MetaTags
-            combined = {**finding_metatags, **finding_metachecks}
+            combined = {**finding_metatags, **finding_metachecks, **finding_metaaccount, **finding_metatrails}
 
             for finding in mh_findings[mh_finding]["findings"]:
                 for f, v in finding.items():

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -9,6 +9,6 @@ provider "aws" {
 data "aws_caller_identity" "current" {}
 
 locals {
-  account_id          = data.aws_caller_identity.current.account_id
-  prefix              = "metahub"
+  account_id = data.aws_caller_identity.current.account_id
+  prefix     = "metahub"
 }


### PR DESCRIPTION
- AWS Security Hub actions (`--enrich-findings` and `--update-findings`) can now be run without confirmation (useful for automated workflows like Custom Actions/Lambdas)
- New Lambda Behaviour for AWS Security Hub custom actions: MetaHub will be executed for each finding with Meta* and enrich the finding back in Security Hub in an automated way. 
- Terraform code for the Lambda improved: IAM policies, layers, etc.
- Enrich Findings functionality now also adds MetaTrails and MetaAccount. 
- Enrich Findings functionality nows converts MetaChecks to booleans to avoid reaching maximum size limitation from API and make the AWS Security Hub filters really useful. 