### PR TITLE
Impact scoring

### DIFF
--- a/lib/config/impact.yaml
+++ b/lib/config/impact.yaml
@@ -7,7 +7,7 @@
 #       Score: Score for this value
 
 status:
-  weight: 10
+  weight: 50
   values:
     - attached:
         score: 1
@@ -21,43 +21,45 @@ status:
         score: 0
 
 exposure:
-  weight: 1
+  weight: 25
   values:
     - effectively-public:
         score: 1
     - restricted-public:
         score: 0.4
-    - unknown-public:
-        score: 0
     - unrestricted-private:
-        score: 0.5
+        score: 0.3
+    - launch-public:
+        score: 0.1
     - restricted:
         score: 0
     - unknown:
         score: 0
 
 access:
-  weight: 1
+  weight: 25
   values:
     - unrestricted:
         score: 1
     - untrusted-principal:
-        score: 0.8
+        score: 0.7
     - unrestricted-principal:
-        score: 0.5
+        score: 0.4
     - cross-account-principal:
-        score: 0.5
-    - unrestricted-actions:
-        score: 0.5
+        score: 0.3
     - dangerous-actions:
-        score: 0.5
+        score: 0.3
+    - unrestricted-actions:
+        score: 0.3
+    - unrestricted-service:
+        score: 0.1
     - restricted:
         score: 0
     - unknown:
         score: 0
 
 encryption:
-  weight: 0.1
+  weight: 10
   values:
     - unencrypted:
         score: 1
@@ -67,7 +69,7 @@ encryption:
         score: 0
 
 environment:
-  weight: 1
+  weight: 15
   values:
     - production:
         score: 1

--- a/lib/impact/access.py
+++ b/lib/impact/access.py
@@ -118,6 +118,16 @@ class Access:
         ):
             return {"unknown": access_checks}
 
+        # Resources without policies are unknown.
+        if (
+            bucket_acl is None
+            and resource_policy is None
+            and inline_policies is None
+            and iam_policies is None
+            and iam_roles is None
+        ):
+            return {"unknown": access_checks}
+
         # We return the most critical access check
         if "unrestricted" in access_checks:
             return {"unrestricted": access_checks}

--- a/lib/impact/encryption.py
+++ b/lib/impact/encryption.py
@@ -79,6 +79,10 @@ class Encryption:
         ):
             return {"unknown": encryption_checks}
 
+        # Resources without unencrypted resources and no encryption config are unknown.
+        if not unencrypted_resources and resource_encryption_config is None:
+            return {"unknown": encryption_checks}
+
         if unencrypted_resources or resource_encryption_config is False:
             return {"unencrypted": encryption_checks}
 

--- a/lib/impact/exposure.py
+++ b/lib/impact/exposure.py
@@ -127,6 +127,14 @@ class Exposure:
         ):
             return {"unknown": exposure_checks}
 
+        # Resources without public config, security groups or resource policy are unknown.
+        if (
+            resource_public_config is None
+            and not unrestricted_ingress_rules
+            and not unrestricted_policy_access
+        ):
+            return {"unknown": exposure_checks}
+
         # Effectively Public If:
         # 1. Public config and unrestricted SG ingress rules
         # 2. Public config and no SG and no resource policy
@@ -154,7 +162,7 @@ class Exposure:
 
         # Restricted Private If:
         # 1. No public config and unrestricted SG ingress rules or unrestricted policy access
-        if not resource_public_config and (
+        if resource_public_config is False and (
             unrestricted_ingress_rules or unrestricted_policy_access
         ):
             return {"unrestricted-private": exposure_checks}


### PR DESCRIPTION
- Mark as unknown the properties for resources where we don't have enough context or associations 
- New context properties for resource type: `AwsEc2Subnet`
- Update Impact scoring default template 