### PR TITLE
Enrichment and Terraform

### DIFF
--- a/lib/config/configuration.py
+++ b/lib/config/configuration.py
@@ -7,6 +7,17 @@
 # Default filters for Security Hub
 sh_default_filters = {"RecordState": ["ACTIVE"], "WorkflowStatus": ["NEW"]}
 
+# Enrichment fields for Security Hub when using the option --enrich-findings
+# Choose from: tags, config, account, cloudtrail, associations, impact
+sh_enrich_with = [
+    "tags",
+    "config",
+    "account",
+    "cloudtrail",
+    "associations",
+    "impact",
+]
+
 
 # ---------------------------------- #
 # Impact Configurations              #

--- a/lib/context/resources/Base.py
+++ b/lib/context/resources/Base.py
@@ -165,6 +165,13 @@ class ContextBase:
                     self.all_associations[r] = resource_drilled_output
                     if level < 1 and resource_drilled:
                         check_associated_resources(resource_drilled, level + 1)
+                    # This is an expensive operation, we only do it for some resources:
+                    if (
+                        level < 2
+                        and resource_drilled
+                        and self.resource_type == "AwsEc2SecurityGroup"
+                    ):
+                        check_associated_resources(resource_drilled, level + 1)
 
             # IAM Policies
             if (

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -60,7 +60,7 @@ def get_parser():
     )
 
     # Group: Security Hub
-    group_security_hub = parser.add_argument_group("Security Hub Options")
+    group_security_hub = parser.add_argument_group("Security Findings Options")
     group_security_hub.add_argument(
         "--sh-assume-role",
         default=None,

--- a/lib/lambda.py
+++ b/lib/lambda.py
@@ -6,21 +6,22 @@ def lambda_handler(event, context):
     logger = get_logger("INFO")
 
     # Add your custom options here (e.g. Only Critical: ["--sh-filters", "SeverityLabel=CRITICAL"])
-
-    # - Options for running Lambda from Security Hub Custom Actions
-    SH_CUSTOM_OPTIONS = [
-        "--enrich-findings",
-    ]
-
-    # - Options when running Lambda from any other source
+    # Only used if running lambda manually, not from Security Hub Custom Actions
     CUSTOM_OPTIONS = []
+
+    # - Actions the lambda will execute, if you don't need actions, keep this list empty
+    # Example, for enriching findings:
+    # ACTIONS = [
+    #     "--enrich-findings",
+    #     "--no-actions-confirmation",
+    # ]
+    ACTIONS = []
 
     # This are the minimum options required to run the Lambda, don't change this
     LAMBDA_OPTIONS = [
         "--output-modes",
         "lambda",
         "--no-banners",
-        "--no-actions-confirmation",
     ]
 
     # Lambda execution
@@ -39,17 +40,10 @@ def lambda_handler(event, context):
         for finding in event_detail.get("findings"):
             finding_id = finding.get("Id")
             logger.info("Security Hub Finding: %s", finding_id)
-            CUSTOM_OPTIONS = SH_CUSTOM_OPTIONS
-            LAMBDA_OPTIONS = [  # You shouldn't need to change this
-                "--output-modes",
-                "lambda",
-                "--no-banners",
-                "--sh-filters",
-                f"Id={finding_id}",
-                "--no-actions-confirmation",
-            ]
+            CUSTOM_OPTIONS = []
+            LAMBDA_OPTIONS.extend(["--sh-filters", f"Id={finding_id}"])
 
-    OPTIONS = CUSTOM_OPTIONS + LAMBDA_OPTIONS
+    OPTIONS = LAMBDA_OPTIONS + ACTIONS + CUSTOM_OPTIONS
 
     logger.info("Executing with options: %s", OPTIONS)
     exec = lib.main.main(OPTIONS)

--- a/lib/outputs.py
+++ b/lib/outputs.py
@@ -230,15 +230,14 @@ def generate_output_html(
     template = templateEnv.get_template(TEMPLATE_FILE)
     # Convert Config to Boolean
     for resource_arn in mh_findings:
-        if (
-            "config" in mh_findings[resource_arn]
-            and mh_findings[resource_arn]["config"]
-        ):
-            for config in mh_findings[resource_arn]["config"]:
-                if bool(mh_findings[resource_arn]["config"][config]):
-                    mh_findings[resource_arn]["config"][config] = True
-                else:
-                    mh_findings[resource_arn]["config"][config] = False
+        keys_to_convert = ["config", "associations"]
+        for key in keys_to_convert:
+            if key in mh_findings[resource_arn] and mh_findings[resource_arn][key]:
+                for config in mh_findings[resource_arn][key]:
+                    if bool(mh_findings[resource_arn][key][config]):
+                        mh_findings[resource_arn][key][config] = True
+                    else:
+                        mh_findings[resource_arn][key][config] = False
 
     with open(WRITE_FILE, "w", encoding="utf-8") as f:
         html = template.render(

--- a/terraform/sh-action.tf
+++ b/terraform/sh-action.tf
@@ -1,0 +1,30 @@
+resource "aws_securityhub_action_target" "action" {
+  name        = "MetaHub"
+  identifier  = "MetaHub"
+  description = "Executes MetaHub"
+}
+
+resource "aws_cloudwatch_event_rule" "rule" {
+  name        = "metahub-rule"
+  description = "Capture each AWS Console Sign In"
+
+  event_pattern = jsonencode({
+    "source" : ["aws.securityhub"],
+    "detail-type" : ["Security Hub Findings - Custom Action"],
+    "resources" : ["${aws_securityhub_action_target.action.arn}"],
+  })
+}
+
+resource "aws_cloudwatch_event_target" "target" {
+  rule      = aws_cloudwatch_event_rule.rule.name
+  target_id = "SendToMetaHub"
+  arn       = aws_lambda_function.lambda_zip.arn
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.lambda_zip.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.rule.arn
+}

--- a/terraform/sh-insights.tf
+++ b/terraform/sh-insights.tf
@@ -1,0 +1,96 @@
+# Insights
+
+resource "aws_securityhub_insight" "exposure_restricted" {
+  filters {
+    record_state {
+      comparison = "EQUALS"
+      value      = "ACTIVE"
+    }
+    user_defined_values {
+      comparison = "EQUALS"
+      key        = "exposure"
+      value      = "restricted"
+    }
+  }
+
+  group_by_attribute = "ResourceId"
+
+  name = "MetaHub Exposure: Restricted"
+
+}
+
+resource "aws_securityhub_insight" "exposure_launch_public" {
+  filters {
+    record_state {
+      comparison = "EQUALS"
+      value      = "ACTIVE"
+    }
+    user_defined_values {
+      comparison = "EQUALS"
+      key        = "exposure"
+      value      = "launch-public"
+    }
+  }
+
+  group_by_attribute = "ResourceId"
+
+  name = "MetaHub Exposure: Launch Public"
+
+}
+
+resource "aws_securityhub_insight" "exposure_unrestricted_private" {
+  filters {
+    record_state {
+      comparison = "EQUALS"
+      value      = "ACTIVE"
+    }
+    user_defined_values {
+      comparison = "EQUALS"
+      key        = "exposure"
+      value      = "unrestricted-private"
+    }
+  }
+
+  group_by_attribute = "ResourceId"
+
+  name = "MetaHub Exposure: Unrestricted Private"
+
+}
+
+resource "aws_securityhub_insight" "exposure_restricted_public" {
+  filters {
+    record_state {
+      comparison = "EQUALS"
+      value      = "ACTIVE"
+    }
+    user_defined_values {
+      comparison = "EQUALS"
+      key        = "exposure"
+      value      = "restricted-public"
+    }
+  }
+
+  group_by_attribute = "ResourceId"
+
+  name = "MetaHub Exposure: Restricted Public"
+
+}
+
+resource "aws_securityhub_insight" "exposure_effectively_public" {
+  filters {
+    record_state {
+      comparison = "EQUALS"
+      value      = "ACTIVE"
+    }
+    user_defined_values {
+      comparison = "EQUALS"
+      key        = "exposure"
+      value      = "effectively-public"
+    }
+  }
+
+  group_by_attribute = "ResourceId"
+
+  name = "MetaHub Exposure: Effectively Public"
+
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,5 +1,5 @@
 variable "region" {
-  default = "us-east-1"
+  default = "eu-west-1"
 }
 
 provider "aws" {


### PR DESCRIPTION
- Enrichment Function Improvements: When enriching a finding, all context categories (tags, account, config, associations, cloudtrail, and impact) are added by default, and this option is configurable using the configuration file. We now use the `Criticality` field for `Impact Scoring`. 
- The lambda function is no longer configured to enrich findings by default; you need to enable it in the code manually. 
- Enabled 2 levels of recursion for some resource types, which seems to be safe and useful. 
- The Terraform Code now creates the Security Hub custom action and connects it to the Lambda! 
- The Terraform Code now creates Security Hub insights for some of the Impact metrics!