### PR TITLE
New customisable environment definition support

### DIFF
--- a/lib/config/configuration.py
+++ b/lib/config/configuration.py
@@ -60,24 +60,48 @@ dangerous_iam_actions = [
 # Days to consider a resource (key) unrotated
 days_to_consider_unrotated = 90
 
-# Environment Tags Definition
-# tag_ENVIRONMENT = {"TAG-KEY": ["TAG-VALUE1", "TAG-VALUE1", "TAG-VALUE3"]}
-tags_production = {
-    "Environment": ["Production", "production", "prd"],
-    "Env": ["Production", "production", "prd"],
-    "environment": ["Production", "production", "prd"],
-}
-tags_staging = {
-    "Environment": ["Staging", "staging", "stg"],
-    "Env": ["Staging", "staging", "stg"],
-    "environment": ["Staging", "staging", "stg"],
-}
-tags_development = {
-    "Environment": ["Development", "development", "dev"],
-    "Env": ["Development", "development", "dev"],
-    "environment": ["Development", "development", "dev"],
-}
+# Environment Definition
+# You can define the environment by tags, account id or account alias.
+# You can define how many environments you want, then assign each environment a value in the file: lib/config/impact.yaml
 
+environments = {
+    "production": {
+        "tags": {
+            "Environment": ["Production", "production", "prd"],
+            "environment": ["Production", "production", "prd"],
+            "Env": ["Production", "production", "prd"],
+            "env": ["Production", "production", "prd"],
+        },
+        "account": {
+            "account_ids": ["123456789012"],
+            "account_aliases": ["production", "prod"],
+        },
+    },
+    "staging": {
+        "tags": {
+            "Environment": ["Staging", "staging", "stg"],
+            "environment": ["Staging", "staging", "stg"],
+            "Env": ["Staging", "staging", "stg"],
+            "env": ["Staging", "staging", "stg"],
+        },
+        "account": {
+            "account_ids": ["123456789012"],
+            "account_aliases": ["staging", "stg"],
+        },
+    },
+    "development": {
+        "tags": {
+            "Environment": ["Development", "development", "dev"],
+            "environment": ["Development", "development", "dev"],
+            "Env": ["Development", "development", "dev"],
+            "env": ["Development", "development", "dev"],
+        },
+        "account": {
+            "account_ids": ["123456789012"],
+            "account_aliases": ["development", "dev"],
+        },
+    },
+}
 
 # ---------------------------------- #
 # Output Configurations              #

--- a/lib/impact/environment.py
+++ b/lib/impact/environment.py
@@ -1,4 +1,4 @@
-from lib.config.configuration import tags_development, tags_production, tags_staging
+from lib.config.configuration import environments
 
 
 class Environment:
@@ -8,23 +8,43 @@ class Environment:
     def get_environment(self, resource_arn, resource_values):
         self.logger.info("Calculating environment for resource: %s", resource_arn)
 
-        def check_tags(tags_environment):
-            tags = resource_values.get("tags", {})
-            if tags:
-                for tag_key, tag_values in tags_environment.items():
+        def check_tags(environment_definition):
+            resource_tags = resource_values.get("tags", {})
+            if resource_tags:
+                for tag_key, tag_values in environment_definition.items():
                     for tag_value in tag_values:
-                        if tag_key in tags and tags[tag_key] == tag_value:
+                        if (
+                            tag_key in resource_tags
+                            and resource_tags[tag_key] == tag_value
+                        ):
                             return True, {tag_key: tag_value}
             return False, False
 
-        envs = {
-            "production": tags_production,
-            "staging": tags_staging,
-            "development": tags_development,
-        }
-        for env in envs:
-            check, tags_matched = check_tags(envs[env])
-            if check:
-                return {env: tags_matched}
+        def check_account(environment_definition):
+            resource_AwsAccountId = resource_values.get("AwsAccountId", "")
+            resouce_account = resource_values.get("account", {})
+            # Check by ID
+            if resource_AwsAccountId and "account_ids" in environment_definition:
+                if resource_AwsAccountId in environment_definition["account_ids"]:
+                    return True, {"account_id": resource_AwsAccountId}
+            # Check by Alias
+            if resouce_account:
+                if "account_aliases" in environment_definition:
+                    if (
+                        resouce_account.get("Alias")
+                        in environment_definition["account_aliases"]
+                    ):
+                        return True, {"account_alias": resouce_account.get("Alias")}
+            return False, False
+
+        for env in environments:
+            # tags_matched, tags_details = check_tags(environments[env].get("tags", {}))
+            # if tags_matched:
+            #     return {env: {"tags": tags_details}}
+            account_matched, account_details = check_account(
+                environments[env].get("account", {})
+            )
+            if account_matched:
+                return {env: {"account": account_details}}
 
         return {"unknown": {}}


### PR DESCRIPTION
You can now define how many environments you need based on your context. 
The default configuration comes with `production`, `staging`, and `development`, but you can now add/remove or change these environments and the impact scoring value assigned to them. 
You can now define how to identify an environment by Account ID or Account Alias. 